### PR TITLE
Export pod annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ Substitute for kube-state-metrics functionality before:
 # Metrics
 
 - `kube_namespace_annotations`: includes labels for `namespace`, `key` and `value`
+- `kube_pod_annotations`: includes labels for `pod`, `namespace`, `key` and `value`
+

--- a/README.md
+++ b/README.md
@@ -2,13 +2,34 @@
 
 [![Docker Repository on Quay](https://quay.io/repository/utilitywarehouse/kube-namespace-annotations-exporter/status "Docker Repository on Quay")](https://quay.io/repository/utilitywarehouse/kube-namespace-annotations-exporter)
 
-Exports namespace metrics as annotations.
+Exports pod and namespace annotations as metrics.
 
-Substitute for kube-state-metrics functionality before:
+The namespace metrics are a substitute for old kube-state-metrics functionality:
 - https://github.com/kubernetes/kube-state-metrics/pull/859
 
-# Metrics
+## Metrics
 
 - `kube_namespace_annotations`: includes labels for `namespace`, `key` and `value`
 - `kube_pod_annotations`: includes labels for `pod`, `namespace`, `key` and `value`
+
+## Cardinality
+
+By default, every annotation is exported for every pod and namespace. This
+could produce a large number of series, so to mitigate this, you can provide a list
+of annotations that you want to export with the flags `-namespace-annotations`
+and `-pod-annotations`.
+
+For example:
+```
+./kube-namespace-annotations-exporter \
+  -pod-annotations="prometheus.io/scrape" \
+  -pod-annotations="prometheus.io/path" \
+  -pod-annotations="kubernetes.io/psp"
+```
+
+The flags can also be provided as a comma-delimited list:
+```
+./kube-namespace-annotations-exporter \
+  -pod-annotations="prometheus.io/scrape,prometheus.io/path,kubernetes.io/psp"
+```
 

--- a/flags.go
+++ b/flags.go
@@ -1,0 +1,27 @@
+package main
+
+import "strings"
+
+type StringSliceFlag struct {
+	Values []string
+
+	changed bool
+}
+
+func (s *StringSliceFlag) String() string {
+	return strings.Join(s.Values, ",")
+}
+
+func (s *StringSliceFlag) Set(value string) error {
+	if !s.changed {
+		s.Values = []string{}
+		s.changed = true
+	}
+	s.Values = append(s.Values, strings.Split(value, ",")...)
+
+	return nil
+}
+
+func (s *StringSliceFlag) StringSlice() []string {
+	return s.Values
+}

--- a/kube/namespace_watch.go
+++ b/kube/namespace_watch.go
@@ -15,6 +15,7 @@ import (
 )
 
 type namespaceWatcher struct {
+	annotations  []string
 	client       kubernetes.Interface
 	resyncPeriod time.Duration
 	stopChannel  chan struct{}
@@ -22,8 +23,9 @@ type namespaceWatcher struct {
 	Metrics      metrics.PrometheusInterface
 }
 
-func NewNamespaceWatcher(client kubernetes.Interface, resyncPeriod time.Duration, metrics metrics.PrometheusInterface) *namespaceWatcher {
+func NewNamespaceWatcher(client kubernetes.Interface, resyncPeriod time.Duration, metrics metrics.PrometheusInterface, annotations []string) *namespaceWatcher {
 	return &namespaceWatcher{
+		annotations:  annotations,
 		client:       client,
 		resyncPeriod: resyncPeriod,
 		stopChannel:  make(chan struct{}),
@@ -33,7 +35,7 @@ func NewNamespaceWatcher(client kubernetes.Interface, resyncPeriod time.Duration
 
 func (nw *namespaceWatcher) updateNamespaceMetrics() {
 	nsList := nw.List()
-	nw.Metrics.UpdateNamespaceAnnotations(nsList)
+	nw.Metrics.UpdateNamespaceAnnotations(nsList, nw.annotations)
 }
 
 func (nw *namespaceWatcher) eventHandler(eventType watch.EventType, old *v1.Namespace, new *v1.Namespace) {

--- a/kube/pod_watch.go
+++ b/kube/pod_watch.go
@@ -1,0 +1,104 @@
+package kube
+
+import (
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/utilitywarehouse/kube-namespace-annotations-exporter/metrics"
+)
+
+type podWatcher struct {
+	annotations  []string
+	client       kubernetes.Interface
+	resyncPeriod time.Duration
+	stopChannel  chan struct{}
+	store        cache.Store
+	Metrics      metrics.PrometheusInterface
+}
+
+func NewPodWatcher(client kubernetes.Interface, resyncPeriod time.Duration, metrics metrics.PrometheusInterface, annotations []string) *podWatcher {
+	return &podWatcher{
+		annotations:  annotations,
+		client:       client,
+		resyncPeriod: resyncPeriod,
+		stopChannel:  make(chan struct{}),
+		Metrics:      metrics,
+	}
+}
+
+func (pw *podWatcher) updateMetrics() {
+	podList := pw.List()
+	pw.Metrics.UpdatePodAnnotations(podList, pw.annotations)
+}
+
+func (pw *podWatcher) eventHandler(eventType watch.EventType, old *v1.Pod, new *v1.Pod) {
+	switch eventType {
+	case watch.Added, watch.Modified, watch.Deleted:
+		pw.updateMetrics()
+	default:
+		fmt.Println(
+			fmt.Sprintf(
+				"[Info] Unknown pod event received: %v",
+				eventType,
+			),
+		)
+	}
+}
+
+func (pw *podWatcher) Start() {
+	listWatch := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return pw.client.CoreV1().Pods("").List(options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return pw.client.CoreV1().Pods("").Watch(options)
+		},
+	}
+	eventHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			pw.eventHandler(watch.Added, nil, obj.(*v1.Pod))
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			pw.eventHandler(watch.Modified, oldObj.(*v1.Pod), newObj.(*v1.Pod))
+		},
+		DeleteFunc: func(obj interface{}) {
+			pw.eventHandler(watch.Deleted, obj.(*v1.Pod), nil)
+		},
+	}
+	store, controller := cache.NewInformer(listWatch, &v1.Pod{}, pw.resyncPeriod, eventHandler)
+	pw.store = store
+	fmt.Println("[Info] Starting pod watcher")
+	// Running controller will block until writing on the stop channel.
+	controller.Run(pw.stopChannel)
+	fmt.Println("[Info] Stopped pod watcher")
+}
+
+func (pw *podWatcher) Stop() {
+	fmt.Println("[Info] Stopping pod watcher")
+	close(pw.stopChannel)
+}
+
+func (pw *podWatcher) List() []v1.Pod {
+	var podList []v1.Pod
+	for _, obj := range pw.store.List() {
+		pod, ok := obj.(*v1.Pod)
+		if !ok {
+			fmt.Println(
+				fmt.Sprintf(
+					"[Error] Cannot read pod object: %s",
+					obj,
+				),
+			)
+			continue
+		}
+		podList = append(podList, *pod)
+	}
+	return podList
+}

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -14,12 +13,14 @@ import (
 )
 
 var (
-	flagPodAnnotations = &StringSliceFlag{}
-	flagKubeConfigPath = flag.String("config", "", "Path of a kube config file, if not provided the app will try to get in cluster config")
-	flagResyncPeriod   = flag.Duration("resync-period", 60*time.Minute, "Namespace watcher cache resync period")
+	flagNamespaceAnnotations = &StringSliceFlag{}
+	flagPodAnnotations       = &StringSliceFlag{}
+	flagKubeConfigPath       = flag.String("config", "", "Path of a kube config file, if not provided the app will try to get in cluster config")
+	flagResyncPeriod         = flag.Duration("resync-period", 60*time.Minute, "Namespace watcher cache resync period")
 )
 
 func main() {
+	flag.Var(flagNamespaceAnnotations, "namespace-annotations", "Annotations to export for namespaces. Can be set multiple times and/or in comma-delimited form. By default all annotations will be exported.")
 	flag.Var(flagPodAnnotations, "pod-annotations", "Annotations to export for pods. Can be set multiple times and/or in comma-delimited form. By default all annotations will be exported.")
 	flag.Parse()
 
@@ -38,6 +39,7 @@ func main() {
 		// stored in cache.
 		*flagResyncPeriod,
 		metrics,
+		flagNamespaceAnnotations.StringSlice(),
 	)
 	go nsWatcher.Start()
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 var (
 	flagNamespaceAnnotations = &StringSliceFlag{}
 	flagPodAnnotations       = &StringSliceFlag{}
-	flagKubeConfigPath       = flag.String("config", "", "Path of a kube config file, if not provided the app will try to get in cluster config")
+	flagKubeConfigPath       = flag.String("config", "", "Path of a kube config file, if not provided the app will try $KUBECONFIG, $HOME/.kube/config or in cluster config")
 	flagResyncPeriod         = flag.Duration("resync-period", 60*time.Minute, "Namespace watcher cache resync period")
 )
 


### PR DESCRIPTION
I would like to construct an alert that identifies when the vault sidecar injection has failed by returning series for pods that have the injection annotation but no credentials agent container:
``` 
kube_pod_annotations{key="injector.tumblr.com/request",value=~"vault-sidecar-.*"} unless on (pod,namespace) kube_pod_container_info{container=~"vault-credentials-agent.*"}
```
This PR enables this by exporting annotations for pods.

To limit cardinality, I've added a filter for specific annotations. I've also added the same filter to namespace annotations as well.

I've tweaked the kube client creation to support loading config from more locations too.