### PR TITLE
Remove resync-period

### DIFF
--- a/kube/namespace_watch.go
+++ b/kube/namespace_watch.go
@@ -3,7 +3,6 @@ package kube
 import (
 	"context"
 	"fmt"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,21 +15,19 @@ import (
 )
 
 type namespaceWatcher struct {
-	annotations  []string
-	client       kubernetes.Interface
-	resyncPeriod time.Duration
-	stopChannel  chan struct{}
-	store        cache.Store
-	Metrics      metrics.PrometheusInterface
+	annotations []string
+	client      kubernetes.Interface
+	stopChannel chan struct{}
+	store       cache.Store
+	Metrics     metrics.PrometheusInterface
 }
 
-func NewNamespaceWatcher(client kubernetes.Interface, resyncPeriod time.Duration, metrics metrics.PrometheusInterface, annotations []string) *namespaceWatcher {
+func NewNamespaceWatcher(client kubernetes.Interface, metrics metrics.PrometheusInterface, annotations []string) *namespaceWatcher {
 	return &namespaceWatcher{
-		annotations:  annotations,
-		client:       client,
-		resyncPeriod: resyncPeriod,
-		stopChannel:  make(chan struct{}),
-		Metrics:      metrics,
+		annotations: annotations,
+		client:      client,
+		stopChannel: make(chan struct{}),
+		Metrics:     metrics,
 	}
 }
 
@@ -73,7 +70,7 @@ func (nw *namespaceWatcher) Start() {
 			nw.eventHandler(watch.Deleted, obj.(*v1.Namespace), nil)
 		},
 	}
-	store, controller := cache.NewInformer(listWatch, &v1.Namespace{}, nw.resyncPeriod, eventHandler)
+	store, controller := cache.NewInformer(listWatch, &v1.Namespace{}, 0, eventHandler)
 	nw.store = store
 	fmt.Println("[Info] Starting namespace watcher")
 	// Running controller will block until writing on the stop channel.

--- a/kube/pod_watch.go
+++ b/kube/pod_watch.go
@@ -3,7 +3,6 @@ package kube
 import (
 	"context"
 	"fmt"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,21 +15,19 @@ import (
 )
 
 type podWatcher struct {
-	annotations  []string
-	client       kubernetes.Interface
-	resyncPeriod time.Duration
-	stopChannel  chan struct{}
-	store        cache.Store
-	Metrics      metrics.PrometheusInterface
+	annotations []string
+	client      kubernetes.Interface
+	stopChannel chan struct{}
+	store       cache.Store
+	Metrics     metrics.PrometheusInterface
 }
 
-func NewPodWatcher(client kubernetes.Interface, resyncPeriod time.Duration, metrics metrics.PrometheusInterface, annotations []string) *podWatcher {
+func NewPodWatcher(client kubernetes.Interface, metrics metrics.PrometheusInterface, annotations []string) *podWatcher {
 	return &podWatcher{
-		annotations:  annotations,
-		client:       client,
-		resyncPeriod: resyncPeriod,
-		stopChannel:  make(chan struct{}),
-		Metrics:      metrics,
+		annotations: annotations,
+		client:      client,
+		stopChannel: make(chan struct{}),
+		Metrics:     metrics,
 	}
 }
 
@@ -73,7 +70,7 @@ func (pw *podWatcher) Start() {
 			pw.eventHandler(watch.Deleted, obj.(*v1.Pod), nil)
 		},
 	}
-	store, controller := cache.NewInformer(listWatch, &v1.Pod{}, pw.resyncPeriod, eventHandler)
+	store, controller := cache.NewInformer(listWatch, &v1.Pod{}, 0, eventHandler)
 	pw.store = store
 	fmt.Println("[Info] Starting pod watcher")
 	// Running controller will block until writing on the stop channel.

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/utilitywarehouse/kube-annotations-exporter/kube"
@@ -16,7 +15,6 @@ var (
 	flagNamespaceAnnotations = &StringSliceFlag{}
 	flagPodAnnotations       = &StringSliceFlag{}
 	flagKubeConfigPath       = flag.String("config", "", "Path of a kube config file, if not provided the app will try $KUBECONFIG, $HOME/.kube/config or in cluster config")
-	flagResyncPeriod         = flag.Duration("resync-period", 60*time.Minute, "Namespace watcher cache resync period")
 )
 
 func main() {
@@ -35,9 +33,6 @@ func main() {
 
 	nsWatcher := kube.NewNamespaceWatcher(
 		kubeClient,
-		// Resync will trigger an onUpdate event for everything that is
-		// stored in cache.
-		*flagResyncPeriod,
 		metrics,
 		flagNamespaceAnnotations.StringSlice(),
 	)
@@ -45,9 +40,6 @@ func main() {
 
 	podWatcher := kube.NewPodWatcher(
 		kubeClient,
-		// Resync will trigger an onUpdate event for everything that is
-		// stored in cache.
-		*flagResyncPeriod,
 		metrics,
 		flagPodAnnotations.StringSlice(),
 	)


### PR DESCRIPTION
The hourly resync causes a large CPU spike when there's a lot of pods in the cluster because we reset the metric and reevaluate the whole list of pods for every event (the resync resubmits every cached pod as an update event). We could address this by implementing our own 'resync' that runs updateMetrics once every hour and that would achieve the same thing less expensively.

However, I'm sceptical that there's much value in resyncing at all. Pod events happen pretty frequently anyway. Even in our quietest clusters it seems like a new pod starts at least every 6 hours. Namespaces are much more infrequent but even so I'm not sure exactly what we expect could go wrong with updateMetrics that we think might be solved by calling it again some time later. And even if we do have a bug that unpredictably misses metrics, maybe it's better to surface it rather than relying on a fail safe to gloss over it on an hourly basis.